### PR TITLE
Modify nested detection loop

### DIFF
--- a/src/main/java/com/bc/zarr/ZarrArray.java
+++ b/src/main/java/com/bc/zarr/ZarrArray.java
@@ -136,30 +136,30 @@ public class ZarrArray {
                 total *= i;
             }
 
-            int attempts = 0;
-
             for (int ignore = 0; ignore < total; ignore++) { // essentially a while(true) for our known maximum.
-                int j;
-                for (j = 0; j < n; j++) {
-                    // This n-dim loops allows to walk through all possible values for all dimensions.
-                    for (boolean test : Arrays.asList(true, false)) {
-                        attempts++;
-                        final String chunkFilename = ZarrUtils.createChunkFilename(ptr, test);
-                        final ZarrPath chunkFilePath = relativePath.resolve(chunkFilename);
-                        try (final InputStream storageStream = store.getInputStream(chunkFilePath.storeKey)) {
-                            if (storageStream != null) { // TODO: test available() ?
-                                nested = test;
-                                break;
-                            }
+                // This n-dim loops allows to walk through all possible values for all dimensions.
+                for (boolean test : Arrays.asList(true, false)) {
+                    final String chunkFilename = ZarrUtils.createChunkFilename(ptr, test);
+                    final ZarrPath chunkFilePath = relativePath.resolve(chunkFilename);
+                    try (final InputStream storageStream = store.getInputStream(chunkFilePath.storeKey)) {
+                        if (storageStream != null) { // TODO: test available() ?
+                            nested = test;
+                            break;
                         }
                     }
-
-                    // Increment and/or exit
-                    ptr[j]++;
-                    if (ptr[j] < shape[j]) break;
-                    ptr[j] = 0;
                 }
-                if (j == n) break;
+                if (nested != null) {
+                    break;
+                } else {
+                    for(int j = 0; j < n; j++) {
+                        ptr[j]++;
+                        if(ptr[j] < shape[j]) {
+                            break;
+                        } else {
+                            ptr[j] = 0;
+                        }
+                    }
+                }
             }
 
             if (nested == null) {


### PR DESCRIPTION
The loop which attempts to determine whether a zarr file is nested or not appears to loop through all chunks even after determining the "nestedness". This has caused some timout issues for us. This modified version exits once a nested or not nested chunk is found, and has also re-ordered some of the logic. 